### PR TITLE
Enable building and testing with Travis CI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^NEWS\.md$
 ^cran-comments\.md$
+^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: r
+
+# System dependencies
+apt_packages:
+ - libxml2-dev
+
+# R dependencies for mldr
+r_packages:
+ - XML
+ - circlize
+ - shiny
+
+# Custom settings
+warnings_are_errors: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mldr
+mldr [![Travis](https://img.shields.io/travis/fcharte/mldr.svg)](https://travis-ci.org/fcharte/mldr/)
 ====
 
 Exploratory data analysis and manipulation functions for multi-label data sets along


### PR DESCRIPTION
In order to enable Travis CI tracking for fcharte/mldr, just login to [Travis CI](https://travis-ci.org) and hit the off/on button for the repo.

Configuration for Travis (language and dependencies) is provided in the `.travis.yml` file. A build status badge has been added to the README file.