### PR TITLE
Patch writing of attributes with spaces or quotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,4 @@ Suggests:
 License: LGPL (>= 3) | file LICENSE
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/mldr.R
+++ b/R/mldr.R
@@ -20,6 +20,7 @@
 #'  dataset, which will be taken from the last attributes of the dataset
 #' @param force_read_from_file Set this parameter to TRUE to always read from a local file,
 #'  or set it to FALSE to look for the dataset within the `mldr.datasets` package
+#' @param ... Extra parameters to be passed to 'read_arff'
 #' @return An mldr object containing the multilabel dataset
 #' @seealso \code{\link{mldr_from_dataframe}}, \code{\link{read.arff}}, \code{\link{summary.mldr}}
 #' @examples
@@ -47,7 +48,8 @@ mldr <- function(filename,
                  label_indices,
                  label_names,
                  label_amount,
-                 force_read_from_file = !all(c(missing(xml_file), missing(label_indices), missing(label_names), missing(label_amount), use_xml, auto_extension))) {
+                 force_read_from_file = !all(c(missing(xml_file), missing(label_indices), missing(label_names), missing(label_amount), use_xml, auto_extension)),
+                 ...) {
 
   no_filename <- missing(filename)
   no_xml_file <- missing(xml_file)
@@ -74,7 +76,7 @@ mldr <- function(filename,
     ret_value
   } else {
     if (!no_filename) {
-      do.call(mldr_from_dataframe, read.arff(filename, use_xml, auto_extension, xml_file, label_indices, label_names, label_amount))
+      do.call(mldr_from_dataframe, read.arff(filename, use_xml, auto_extension, xml_file, label_indices, label_names, label_amount, ...))
     } else {
       NULL
     }

--- a/R/mldr.R
+++ b/R/mldr.R
@@ -30,6 +30,10 @@
 #' # Read "yeast.arff" and labels from "yeast.xml"
 #' mymld <- mldr("yeast")
 #'
+#' # Read "yeast.arff" and labels from "yeast.xml", converting categorical
+#' # attributes to factors
+#' mymld <- mldr("yeast", stringsAsFactors = TRUE)
+#'
 #' # Read "yeast-tra.arff" and labels from "yeast.xml"
 #' mymld <- mldr("yeast-tra", xml_file = "yeast.xml")
 #'

--- a/R/read.arff.R
+++ b/R/read.arff.R
@@ -23,9 +23,9 @@
 #'  dataset, which will be taken from the last attributes of the dataset
 #' @param ... Extra parameters that will be passed to the parsers. Currently
 #'  only the option `stringsAsFactors` is available
-#' @return A list containing four members: dataframe (containing the dataset),
-#'  labelIndices (specifying the indices of the attributes that correspond to
-#'  labels), attributes (containing name and type of each attribute) and name of
+#' @return A list containing four members: \code{dataframe} containing the dataset,
+#'  \code{labelIndices} specifying the indices of the attributes that correspond to
+#'  labels, \code{attributes} containing name and type of each attribute and \code{name} of
 #'  the dataset.
 #' @seealso \code{\link{mldr_from_dataframe}}, \code{\link{mldr}}
 #' @examples

--- a/R/read.arff.R
+++ b/R/read.arff.R
@@ -21,6 +21,8 @@
 #'  that should be read as labels
 #' @param label_amount Optional parameter indicating the number of labels in the
 #'  dataset, which will be taken from the last attributes of the dataset
+#' @param ... Extra parameters that will be passed to the parsers. Currently
+#'  only the option `stringsAsFactors` is available
 #' @return A list containing four members: dataframe (containing the dataset),
 #'  labelIndices (specifying the indices of the attributes that correspond to
 #'  labels), attributes (containing name and type of each attribute) and name of
@@ -40,7 +42,7 @@ read.arff <- function(filename,
                       xml_file,
                       label_indices,
                       label_names,
-                      label_amount) {
+                      label_amount, ...) {
 
   no_filename <- missing(filename)
   no_xml_file <- missing(xml_file)
@@ -72,7 +74,7 @@ read.arff <- function(filename,
     # Get file contents
     relation <- NULL
     attrs <- NULL
-    contents <- read_arff_internal(arff_file)
+    contents <- read_arff_internal(arff_file, ...)
     relation <- contents$relation
     attrs <- contents$attributes
     dataset <- contents$dataset
@@ -132,7 +134,7 @@ read.arff <- function(filename,
 # @return List containing the relation string,
 #  a named vector for attributes and a data.frame
 #  for the data section
-read_arff_internal <- function(arff_file) {
+read_arff_internal <- function(arff_file, ...) {
   file_con <- file(arff_file, "rb")
 
   if (!isOpen(file_con))
@@ -165,9 +167,9 @@ read_arff_internal <- function(arff_file) {
   # Build data.frame with @data section
   rawdata <- file_data[data_start:length(file_data)]
   dataset <- if (detect_sparsity(rawdata))
-    parse_sparse_data(rawdata, num_attrs)
+    parse_sparse_data(rawdata, num_attrs, ...)
   else
-    parse_nonsparse_data(rawdata, num_attrs)
+    parse_nonsparse_data(rawdata, num_attrs, ...)
 
   rm(rawdata)
   names(dataset) <- names(attributes)
@@ -272,19 +274,19 @@ detect_sparsity <- function(arff_data) {
 #
 # @param arff_data Content of the data section
 # @return data.frame containing data values
-parse_nonsparse_data <- function(arff_data, num_attrs) {
+parse_nonsparse_data <- function(arff_data, num_attrs, stringsAsFactors = F) {
   data.frame(matrix(
     unlist(strsplit(arff_data, ",", fixed = T)),
     ncol = num_attrs,
     byrow = T
-  ), stringsAsFactors = F)
+  ), stringsAsFactors = stringsAsFactors)
 }
 
 # Builds a data.frame out of sparse ARFF data
 #
 # @param arff_data Content of the data section
 # @return data.frame containing data values
-parse_sparse_data <- function(arff_data, num_attrs) {
+parse_sparse_data <- function(arff_data, num_attrs, stringsAsFactors = F) {
   # Extract data items
   arff_data <- strsplit(gsub("[\\{\\}]", "", arff_data), ",")
   arff_data <- lapply(arff_data, function(item) {
@@ -299,5 +301,5 @@ parse_sparse_data <- function(arff_data, num_attrs) {
   })
 
   # Create and return data.frame
-  data.frame(t(dataset), stringsAsFactors = F)
+  data.frame(t(dataset), stringsAsFactors = stringsAsFactors)
 }

--- a/R/write.arff.R
+++ b/R/write.arff.R
@@ -16,7 +16,15 @@ write_arff <- function(obj, filename, write.xml = FALSE) {
 
   # Create header an attribute lines
   header <- paste("@relation ", obj$name, sep = "")
-  attributes <- paste("@attribute ", names(obj$attributes), " ", obj$attributes, sep = "")
+
+  # Enclose names within quotes if necessary
+  attribute_names <- ifelse(
+    grepl("[' ]", names(obj$attributes)),
+    paste0("'", gsub("'", "\\\\'", names(obj$attributes)), "'"),
+    names(obj$attributes)
+  )
+
+  attributes <- paste("@attribute ", attribute_names, " ", obj$attributes, sep = "")
   data <- obj$dataset[, 1:obj$measures$num.attributes]
   data[is.na(data)] <- '0' # NAs aren't missing values ('?') but 0
   data <- apply(data, 1, function(c) paste(c, collapse = ','))

--- a/R/write.arff.R
+++ b/R/write.arff.R
@@ -1,12 +1,14 @@
-#' @title Writes an \code{mldr} object to a file
-#' @description Save the \code{mldr} content to an ARFF file and the label data to an XML file
-#' @param obj The \code{mldr} object whose content is going to be written
+#' @title Write an \code{"mldr"} object to a file
+#' @description Save the \code{mldr} content to an ARFF file and the label data to an XML file.
+#'  If you need \strong{faster write, more options and support for other formats}, please
+#'  refer to the \code{\link[mldr.datasets]{write.mldr}} function in package mldr.datasets.
+#' @param obj The \code{"mldr"} object whose content is going to be written
 #' @param filename Base name for the files (without extension)
 #' @param write.xml \code{TRUE} or \code{FALSE}, stating if the XML file has to be written
 #' @seealso \code{\link{mldr_from_dataframe}}, \code{\link{mldr}}
-#' @examples
 #'
-#' library(mldr)
+#' In mldr.datasets: \code{\link[mldr.datasets]{write.mldr}}
+#' @examples
 #'
 #' write_arff(emotions, "myemotions")
 #' @export

--- a/man/birds.Rd
+++ b/man/birds.Rd
@@ -19,4 +19,3 @@ summary(birds)
 birds$labels
 }
 \keyword{datasets}
-

--- a/man/concurrenceReport.Rd
+++ b/man/concurrenceReport.Rd
@@ -31,4 +31,3 @@ concurrenceReport(birds)
 \seealso{
 \code{\link{remedial}}, \code{\link{labelInteractions}}
 }
-

--- a/man/emotions.Rd
+++ b/man/emotions.Rd
@@ -19,4 +19,3 @@ summary(emotions)
 emotions$labels
 }
 \keyword{datasets}
-

--- a/man/equals-.mldr.Rd
+++ b/man/equals-.mldr.Rd
@@ -17,4 +17,3 @@
 \description{
 Checks if two mldr objects have the same structure
 }
-

--- a/man/genbase.Rd
+++ b/man/genbase.Rd
@@ -19,4 +19,3 @@ summary(genbase)
 genbase$labels
 }
 \keyword{datasets}
-

--- a/man/labelInteractions.Rd
+++ b/man/labelInteractions.Rd
@@ -29,4 +29,3 @@ labelInteractions(birds)
 \seealso{
 \code{\link{remedial}}, \code{\link{concurrenceReport}}
 }
-

--- a/man/mldr.Rd
+++ b/man/mldr.Rd
@@ -53,6 +53,10 @@ library(mldr)
 # Read "yeast.arff" and labels from "yeast.xml"
 mymld <- mldr("yeast")
 
+# Read "yeast.arff" and labels from "yeast.xml", converting categorical
+# attributes to factors
+mymld <- mldr("yeast", stringsAsFactors = TRUE)
+
 # Read "yeast-tra.arff" and labels from "yeast.xml"
 mymld <- mldr("yeast-tra", xml_file = "yeast.xml")
 
@@ -66,4 +70,3 @@ mymld <- mldr("IMDB.arff", use_xml = FALSE, auto_extension = FALSE)
 \seealso{
 \code{\link{mldr_from_dataframe}}, \code{\link{read.arff}}, \code{\link{summary.mldr}}
 }
-

--- a/man/mldr.Rd
+++ b/man/mldr.Rd
@@ -7,7 +7,7 @@
 mldr(filename, use_xml = TRUE, auto_extension = TRUE, xml_file,
   label_indices, label_names, label_amount,
   force_read_from_file = !all(c(missing(xml_file), missing(label_indices),
-  missing(label_names), missing(label_amount), use_xml, auto_extension)))
+  missing(label_names), missing(label_amount), use_xml, auto_extension)), ...)
 }
 \arguments{
 \item{filename}{Name of the dataset}
@@ -34,6 +34,8 @@ dataset, which will be taken from the last attributes of the dataset}
 
 \item{force_read_from_file}{Set this parameter to TRUE to always read from a local file,
 or set it to FALSE to look for the dataset within the `mldr.datasets` package}
+
+\item{...}{Extra parameters to be passed to 'read_arff'}
 }
 \value{
 An mldr object containing the multilabel dataset

--- a/man/mldrGUI.Rd
+++ b/man/mldrGUI.Rd
@@ -43,4 +43,3 @@ library(mldr)
 mldrGUI()
 }
 }
-

--- a/man/mldr_evaluate.Rd
+++ b/man/mldr_evaluate.Rd
@@ -61,4 +61,3 @@ plot(res$ROC, main = "ROC curve for emotions")
 \seealso{
 \code{\link{mldr}}
 }
-

--- a/man/mldr_from_dataframe.Rd
+++ b/man/mldr_from_dataframe.Rd
@@ -40,4 +40,3 @@ summary(mymldr)
 \seealso{
 \code{\link{mldr}}, \code{\link{summary.mldr}}
 }
-

--- a/man/mldr_transform.Rd
+++ b/man/mldr_transform.Rd
@@ -28,4 +28,3 @@ library(mldr)
 emotionsbr <- mldr_transform(emotions, type = "BR")
 emotionslp <- mldr_transform(emotions, type = "LP")
 }
-

--- a/man/plot.mldr.Rd
+++ b/man/plot.mldr.Rd
@@ -61,4 +61,3 @@ plot(emotions, type = "AT", cex = 0.85)
 plot(emotions, type = "LSH")
 }
 }
-

--- a/man/plus-.mldr.Rd
+++ b/man/plus-.mldr.Rd
@@ -19,4 +19,3 @@ a new \code{mldr} object with all rows in the two parameters
 Generates a new mldr object joining the rows
 in the two mldrs given as input
 }
-

--- a/man/print.mldr.Rd
+++ b/man/print.mldr.Rd
@@ -25,4 +25,3 @@ print(emotions) # Same as above
 \seealso{
 \code{\link{mldr}}, \code{\link{summary.mldr}}
 }
-

--- a/man/read.arff.Rd
+++ b/man/read.arff.Rd
@@ -34,9 +34,9 @@ dataset, which will be taken from the last attributes of the dataset}
 only the option `stringsAsFactors` is available}
 }
 \value{
-A list containing four members: dataframe (containing the dataset),
- labelIndices (specifying the indices of the attributes that correspond to
- labels), attributes (containing name and type of each attribute) and name of
+A list containing four members: \code{dataframe} containing the dataset,
+ \code{labelIndices} specifying the indices of the attributes that correspond to
+ labels, \code{attributes} containing name and type of each attribute and \code{name} of
  the dataset.
 }
 \description{
@@ -54,4 +54,3 @@ mymld <- read.arff("yeast")
 \seealso{
 \code{\link{mldr_from_dataframe}}, \code{\link{mldr}}
 }
-

--- a/man/read.arff.Rd
+++ b/man/read.arff.Rd
@@ -5,7 +5,7 @@
 \title{Read an ARFF file}
 \usage{
 read.arff(filename, use_xml = TRUE, auto_extension = TRUE, xml_file,
-  label_indices, label_names, label_amount)
+  label_indices, label_names, label_amount, ...)
 }
 \arguments{
 \item{filename}{Name of the dataset}
@@ -29,6 +29,9 @@ that should be read as labels}
 
 \item{label_amount}{Optional parameter indicating the number of labels in the
 dataset, which will be taken from the last attributes of the dataset}
+
+\item{...}{Extra parameters that will be passed to the parsers. Currently
+only the option `stringsAsFactors` is available}
 }
 \value{
 A list containing four members: dataframe (containing the dataset),

--- a/man/remedial.Rd
+++ b/man/remedial.Rd
@@ -31,4 +31,3 @@ summary(remedial(birds))
 \seealso{
 \code{\link{concurrenceReport}}, \code{\link{labelInteractions}}
 }
-

--- a/man/sub-.mldr.Rd
+++ b/man/sub-.mldr.Rd
@@ -30,4 +30,3 @@ summary(genbase)         # with the traits of the original MLD
 \seealso{
 \code{\link{mldr_from_dataframe}}, \code{\link{==.mldr}}, \code{\link{+.mldr}}
 }
-

--- a/man/summary.mldr.Rd
+++ b/man/summary.mldr.Rd
@@ -24,4 +24,3 @@ summary(emotions)
 \seealso{
 \code{\link{mldr}}, \code{\link{print.mldr}}
 }
-

--- a/man/write_arff.Rd
+++ b/man/write_arff.Rd
@@ -2,27 +2,28 @@
 % Please edit documentation in R/write.arff.R
 \name{write_arff}
 \alias{write_arff}
-\title{Writes an \code{mldr} object to a file}
+\title{Write an \code{"mldr"} object to a file}
 \usage{
 write_arff(obj, filename, write.xml = FALSE)
 }
 \arguments{
-\item{obj}{The \code{mldr} object whose content is going to be written}
+\item{obj}{The \code{"mldr"} object whose content is going to be written}
 
 \item{filename}{Base name for the files (without extension)}
 
 \item{write.xml}{\code{TRUE} or \code{FALSE}, stating if the XML file has to be written}
 }
 \description{
-Save the \code{mldr} content to an ARFF file and the label data to an XML file
+Save the \code{mldr} content to an ARFF file and the label data to an XML file.
+ If you need \strong{faster write, more options and support for other formats}, please
+ refer to the \code{\link[mldr.datasets]{write.mldr}} function in package mldr.datasets.
 }
 \examples{
-
-library(mldr)
 
 write_arff(emotions, "myemotions")
 }
 \seealso{
 \code{\link{mldr_from_dataframe}}, \code{\link{mldr}}
-}
 
+In mldr.datasets: \code{\link[mldr.datasets]{write.mldr}}
+}


### PR DESCRIPTION
This fixes #30.

Double quotes are not considered since [we don't parse them either](https://github.com/fcharte/mldr/blob/master/R/read.arff.R#L202). According to WEKA, though, [attributes and relations _may_ be enclosed within double quotes](https://weka.wikispaces.com/ARFF+%28stable+version%29#Examples-The @relation Declaration). I'll open another issue for this.
