### PR TITLE
Allow read and write of double-quote enclosed attributes

### DIFF
--- a/R/read.arff.R
+++ b/R/read.arff.R
@@ -201,7 +201,8 @@ parse_attributes <- function(arff_attrs) {
   # We capture any spacing character ignoring those within braces or single quotes,
   # allowing the appearance of escaped single quotes (\').
   #-----------------------------------------------------------------------------------------------------
-  rgx <- "(?:{[^}\\s]*?(\\s+[^}\\s]*?)+}|(?<!\\\\)'[^'\\\\]*(?:\\\\.[^'\\\\]*)*(?<!\\\\)')(*SKIP)(*F)|\\s+"
+  #rgx <- "(?:{[^}\\s]*?(\\s+[^}\\s]*?)+}|(?<!\\\\)'[^'\\\\]*(?:\\\\.[^'\\\\]*)*(?<!\\\\)')(*SKIP)(*F)|\\s+"
+  rgx <- "(?:{(?:.*?)}\\s*$|(?<!\\\\)'[^'\\\\]*(?:.*?)(?<!\\\\)'|(?<!\\\\)\"(?:.*?)(?<!\\\\)\"|(\\s*?)@)(*SKIP)(*F)|\\s+"
   att_list <- strsplit(arff_attrs, rgx, perl = TRUE)
 
   # Structure by rows
@@ -210,8 +211,10 @@ parse_attributes <- function(arff_attrs) {
   rm(att_list)
   # Filter any data that is not an attribute
   att_mat <- att_mat[grepl("\\s*@attribute", att_mat[, 1], ignore.case = TRUE), 2:3]
-  att_mat <- gsub("\\'", "'", att_mat, fixed = T)
   att_mat <- gsub("^'(.*?)'$", "\\1", att_mat, perl = T)
+  att_mat <- gsub('^"(.*?)"$', "\\1", att_mat, perl = T)
+  att_mat[, 1] <- gsub("\\'", "'", att_mat[, 1], fixed = T)
+  att_mat[, 1] <- gsub('\\"', '"', att_mat[, 1], fixed = T)
 
   # Create the named vector
   att_v <- att_mat[, 2]

--- a/R/read.arff.R
+++ b/R/read.arff.R
@@ -201,7 +201,9 @@ parse_attributes <- function(arff_attrs) {
   # We capture any spacing character ignoring those within braces or single quotes,
   # allowing the appearance of escaped single quotes (\').
   #-----------------------------------------------------------------------------------------------------
-  #rgx <- "(?:{[^}\\s]*?(\\s+[^}\\s]*?)+}|(?<!\\\\)'[^'\\\\]*(?:\\\\.[^'\\\\]*)*(?<!\\\\)')(*SKIP)(*F)|\\s+"
+  # Regex tested in https://regex101.com/r/tE5mP1/20
+  #-----------------------------------------------------------------------------------------------------
+
   rgx <- "(?:{(?:.*?)}\\s*$|(?<!\\\\)'[^'\\\\]*(?:.*?)(?<!\\\\)'|(?<!\\\\)\"(?:.*?)(?<!\\\\)\"|(\\s*?)@)(*SKIP)(*F)|\\s+"
   att_list <- strsplit(arff_attrs, rgx, perl = TRUE)
 

--- a/R/write.arff.R
+++ b/R/write.arff.R
@@ -23,7 +23,11 @@ write_arff <- function(obj, filename, write.xml = FALSE) {
   attribute_names <- ifelse(
     grepl("[' ]", names(obj$attributes)),
     paste0("'", gsub("'", "\\\\'", names(obj$attributes)), "'"),
-    names(obj$attributes)
+    ifelse(
+      grepl('[" ]', names(obj$attributes)),
+      paste0('"', gsub('"', '\\\\"', names(obj$attributes)), '"'),
+      names(obj$attributes)
+    )
   )
 
   attributes <- paste("@attribute ", attribute_names, " ", obj$attributes, sep = "")


### PR DESCRIPTION
Fixes #35.

The regex used is tested here: https://regex101.com/r/tE5mP1/20 it needs to identify the correct spaces where to split attribute fields.